### PR TITLE
MNEMONIC-92:Rename DurableNodeValue<E> to DurableSinglyLinkedList<E>

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,13 +256,13 @@ To run several test cases:
   $ mvn -Dtest=MemClusteringNGTest test -pl mnemonic-core -DskipTests=false
   
   $ # a testcase for module "mnemonic-collection" that requires 'pmalloc' memory service to pass
-  $ mvn -Dtest=DurableNodeValueNGTest  test -pl mnemonic-collections -DskipTests=false
+  $ mvn -Dtest=DurableSinglyLinkedListNGTest  test -pl mnemonic-collections -DskipTests=false
   
   $ # a testcase for module "mnemonic-collection" that requires 'pmalloc' memory service to pass
   $ mvn -Dtest=DurablePersonNGTest  test -pl mnemonic-collections -DskipTests=false
   
   $ # a testcase for module "mnemonic-computing-services/mnemonic-utilities-service" that requires 'pmalloc' memory service to pass
-  $ mvn -Dtest=DurableNodeValueNGPrintTest test -pl mnemonic-computing-services/mnemonic-utilities-service -DskipTests=false
+  $ mvn -Dtest=DurableSinglyLinkedListNGPrintTest test -pl mnemonic-computing-services/mnemonic-utilities-service -DskipTests=false
 ```
 
 ### Where is the document ?

--- a/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableSinglyLinkedList.java
+++ b/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableSinglyLinkedList.java
@@ -33,7 +33,7 @@ import org.apache.mnemonic.DurableSetter;
  *
  */
 @DurableEntity
-public abstract class DurableNodeValue<E> implements Durable, Iterable<E> {
+public abstract class DurableSinglyLinkedList<E> implements Durable, Iterable<E> {
   protected transient EntityFactoryProxy[] m_node_efproxies;
   protected transient DurableType[] m_node_gftypes;
 
@@ -100,7 +100,7 @@ public abstract class DurableNodeValue<E> implements Durable, Iterable<E> {
    *
    */
   @DurableGetter(Id = 2L, EntityFactoryProxies = "m_node_efproxies", GenericFieldTypes = "m_node_gftypes")
-  public abstract DurableNodeValue<E> getNext();
+  public abstract DurableSinglyLinkedList<E> getNext();
 
   /**
    * set next node
@@ -112,7 +112,7 @@ public abstract class DurableNodeValue<E> implements Durable, Iterable<E> {
    *          true if want to destroy the exist node
    */
   @DurableSetter
-  public abstract void setNext(DurableNodeValue<E> next, boolean destroy);
+  public abstract void setNext(DurableSinglyLinkedList<E> next, boolean destroy);
 
   /**
    * get an iterator instance of this list
@@ -130,7 +130,7 @@ public abstract class DurableNodeValue<E> implements Durable, Iterable<E> {
    */
   private class Intr implements Iterator<E> {
 
-    protected DurableNodeValue<E> next = null;
+    protected DurableSinglyLinkedList<E> next = null;
 
     /**
      * Constructor
@@ -139,7 +139,7 @@ public abstract class DurableNodeValue<E> implements Durable, Iterable<E> {
      *          the start point for this iterator
      *
      */
-    Intr(DurableNodeValue<E> head) {
+    Intr(DurableSinglyLinkedList<E> head) {
       next = head;
     }
 

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableSinglyLinkedListNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableSinglyLinkedListNGTest.java
@@ -41,7 +41,7 @@ import org.testng.annotations.Test;
  *
  */
 
-public class DurableNodeValueNGTest {
+public class DurableSinglyLinkedListNGTest {
   private long cKEYCAPACITY;
   private Random m_rand;
   private NonVolatileMemAllocator m_act;
@@ -83,11 +83,12 @@ public class DurableNodeValueNGTest {
   public void testSingleNodeValueWithInteger() {
     int val = m_rand.nextInt();
     DurableType gtypes[] = {DurableType.INTEGER};
-    DurableNodeValue<Integer> plln = DurableNodeValueFactory.create(m_act, null, gtypes, false);
+    DurableSinglyLinkedList<Integer> plln = DurableSinglyLinkedListFactory.create(m_act, null, gtypes, false);
     plln.setItem(val, false);
     Long handler = plln.getHandler();
     System.err.println("-------------Start to Restore Integer -----------");
-    DurableNodeValue<Integer> plln2 = DurableNodeValueFactory.restore(m_act, null, gtypes, handler, false);
+    DurableSinglyLinkedList<Integer> plln2 = DurableSinglyLinkedListFactory.restore(m_act, null, gtypes, handler, 
+        false);
     AssertJUnit.assertEquals(val, (int) plln2.getItem());
   }
 
@@ -95,11 +96,12 @@ public class DurableNodeValueNGTest {
   public void testNodeValueWithString() {
     String val = Utils.genRandomString();
     DurableType gtypes[] = {DurableType.STRING};
-    DurableNodeValue<String> plln = DurableNodeValueFactory.create(m_act, null, gtypes, false);
+    DurableSinglyLinkedList<String> plln = DurableSinglyLinkedListFactory.create(m_act, null, gtypes, false);
     plln.setItem(val, false);
     Long handler = plln.getHandler();
     System.err.println("-------------Start to Restore String-----------");
-    DurableNodeValue<String> plln2 = DurableNodeValueFactory.restore(m_act, null, gtypes, handler, false);
+    DurableSinglyLinkedList<String> plln2 = DurableSinglyLinkedListFactory.restore(m_act, null, gtypes, handler, 
+        false);
     AssertJUnit.assertEquals(val, plln2.getItem());
   }
 
@@ -118,12 +120,12 @@ public class DurableNodeValueNGTest {
       }
     } };
 
-    DurableNodeValue<Person<Long>> plln = DurableNodeValueFactory.create(m_act, efproxies, gtypes, false);
+    DurableSinglyLinkedList<Person<Long>> plln = DurableSinglyLinkedListFactory.create(m_act, efproxies, gtypes, false);
     plln.setItem(person, false);
     Long handler = plln.getHandler();
 
-    DurableNodeValue<Person<Long>> plln2 = DurableNodeValueFactory.restore(m_act, efproxies, gtypes, handler,
-        false);
+    DurableSinglyLinkedList<Person<Long>> plln2 = DurableSinglyLinkedListFactory.restore(m_act, efproxies, gtypes, 
+        handler, false);
     AssertJUnit.assertEquals(31, (int) plln2.getItem().getAge());
 
   }
@@ -143,26 +145,26 @@ public class DurableNodeValueNGTest {
       }
     } };
 
-    DurableNodeValue<Person<Long>> firstnv = DurableNodeValueFactory.create(m_act, listefproxies, listgftypes,
-        false);
+    DurableSinglyLinkedList<Person<Long>> firstnv = DurableSinglyLinkedListFactory.create(m_act, listefproxies, 
+        listgftypes, false);
 
-    DurableNodeValue<Person<Long>> nextnv = firstnv;
+    DurableSinglyLinkedList<Person<Long>> nextnv = firstnv;
 
     Person<Long> person;
     long val;
-    DurableNodeValue<Person<Long>> newnv;
+    DurableSinglyLinkedList<Person<Long>> newnv;
     for (int i = 0; i < elem_count; ++i) {
       person = PersonFactory.create(m_act);
       person.setAge((short) m_rand.nextInt(50));
       person.setName(String.format("Name: [%s]", Utils.genRandomString()), true);
       nextnv.setItem(person, false);
-      newnv = DurableNodeValueFactory.create(m_act, listefproxies, listgftypes, false);
+      newnv = DurableSinglyLinkedListFactory.create(m_act, listefproxies, listgftypes, false);
       nextnv.setNext(newnv, false);
       nextnv = newnv;
     }
 
     Person<Long> eval;
-    DurableNodeValue<Person<Long>> iternv = firstnv;
+    DurableSinglyLinkedList<Person<Long>> iternv = firstnv;
     while (null != iternv) {
       System.out.printf(" Stage 1 --->\n");
       eval = iternv.getItem();
@@ -174,8 +176,8 @@ public class DurableNodeValueNGTest {
 
     long handler = firstnv.getHandler();
 
-    DurableNodeValue<Person<Long>> firstnv2 = DurableNodeValueFactory.restore(m_act, listefproxies, listgftypes,
-        handler, false);
+    DurableSinglyLinkedList<Person<Long>> firstnv2 = DurableSinglyLinkedListFactory.restore(m_act, listefproxies, 
+        listgftypes, handler, false);
 
     for (Person<Long> eval2 : firstnv2) {
       System.out.printf(" Stage 2 ---> \n");
@@ -210,12 +212,12 @@ public class DurableNodeValueNGTest {
         if (null != gfields && gfields.length >= 2) {
           val_gftypes = Arrays.copyOfRange(gfields, 1, gfields.length);
         }
-        return DurableNodeValueFactory.restore(allocator, val_efproxies, val_gftypes, phandler, autoreclaim);
+        return DurableSinglyLinkedListFactory.restore(allocator, val_efproxies, val_gftypes, phandler, autoreclaim);
       }
     } };
 
-    DurableNodeValue<DurableNodeValue<Double>> nextnv = null, pre_nextnv = null;
-    DurableNodeValue<Double> elem = null, pre_elem = null, first_elem = null;
+    DurableSinglyLinkedList<DurableSinglyLinkedList<Double>> nextnv = null, pre_nextnv = null;
+    DurableSinglyLinkedList<Double> elem = null, pre_elem = null, first_elem = null;
 
     Long linkhandler = 0L;
 
@@ -227,7 +229,7 @@ public class DurableNodeValueNGTest {
       first_elem = null;
       pre_elem = null;
       for (int v = 0; v < 3; ++v) {
-        elem = DurableNodeValueFactory.create(m_act, elem_efproxies, elem_gftypes, false);
+        elem = DurableSinglyLinkedListFactory.create(m_act, elem_efproxies, elem_gftypes, false);
         val = m_rand.nextDouble();
         elem.setItem(val, false);
         if (null == pre_elem) {
@@ -239,7 +241,7 @@ public class DurableNodeValueNGTest {
         System.out.printf("%f ", val);
       }
 
-      nextnv = DurableNodeValueFactory.create(m_act, linkedefproxies, linkedgftypes, false);
+      nextnv = DurableSinglyLinkedListFactory.create(m_act, linkedefproxies, linkedgftypes, false);
       nextnv.setItem(first_elem, false);
       if (null == pre_nextnv) {
         linkhandler = nextnv.getHandler();
@@ -253,9 +255,9 @@ public class DurableNodeValueNGTest {
 
     long handler = m_act.getHandler(slotKeyId);
 
-    DurableNodeValue<DurableNodeValue<Double>> linkedvals = DurableNodeValueFactory.restore(m_act,
+    DurableSinglyLinkedList<DurableSinglyLinkedList<Double>> linkedvals = DurableSinglyLinkedListFactory.restore(m_act,
         linkedefproxies, linkedgftypes, handler, false);
-    Iterator<DurableNodeValue<Double>> iter = linkedvals.iterator();
+    Iterator<DurableSinglyLinkedList<Double>> iter = linkedvals.iterator();
     Iterator<Double> elemiter = null;
 
     System.out.printf(" Stage 2 -testLinkedNodeValueWithLinkedNodeValue--> \n");

--- a/mnemonic-collections/src/test/resources/testng.xml
+++ b/mnemonic-collections/src/test/resources/testng.xml
@@ -23,7 +23,7 @@
 <suite name="Suite" verbose="1" parallel="tests" thread-count="1">
   <test name="Test">
     <classes>
-      <class name="org.apache.mnemonic.collections.DurableNodeValueNGTest"/> 
+      <class name="org.apache.mnemonic.collections.DurableSinglyLinkedListNGTest"/> 
     </classes>
   </test> <!-- Test -->
 </suite> <!-- Suite -->
@@ -33,5 +33,5 @@
       <class name="org.apache.mnemonic.collections.Person"/>
       <class name="org.apache.mnemonic.collections.DurablePersonNGTest"/>
       <class name="org.apache.mnemonic.collections.DurableListNGTest"/>
-      <class name="org.apache.mnemonic.collections.DurableNodeValueNGTest"/> 
+      <class name="org.apache.mnemonic.collections.DurableSinglyLinkedListNGTest"/> 
  -->

--- a/mnemonic-computing-services/mnemonic-utilities-service/src/test/java/org/apache/mnemonic/service/computingservice/DurableSinglyLinkedListNGPrintTest.java
+++ b/mnemonic-computing-services/mnemonic-utilities-service/src/test/java/org/apache/mnemonic/service/computingservice/DurableSinglyLinkedListNGPrintTest.java
@@ -31,8 +31,8 @@ import org.apache.mnemonic.Durable;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.DurableType;
-import org.apache.mnemonic.collections.DurableNodeValue;
-import org.apache.mnemonic.collections.DurableNodeValueFactory;
+import org.apache.mnemonic.collections.DurableSinglyLinkedList;
+import org.apache.mnemonic.collections.DurableSinglyLinkedListFactory;
 
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -43,7 +43,7 @@ import org.testng.annotations.Test;
  *
  */
 
-public class DurableNodeValueNGPrintTest {
+public class DurableSinglyLinkedListNGPrintTest {
   public static String uri = "./pobj_NodeValue_print.dat";
   private long cKEYCAPACITY;
   private Random m_rand;
@@ -80,14 +80,14 @@ public class DurableNodeValueNGPrintTest {
       }
     } };
 
-    DurableNodeValue<Person<Long>> firstnv = DurableNodeValueFactory.create(m_act, listefproxies, listgftypes,
-        false);
+    DurableSinglyLinkedList<Person<Long>> firstnv = DurableSinglyLinkedListFactory.create(m_act, listefproxies, 
+        listgftypes, false);
 
-    DurableNodeValue<Person<Long>> nextnv = firstnv;
+    DurableSinglyLinkedList<Person<Long>> nextnv = firstnv;
 
     Person<Long> person = null;
     long val;
-    DurableNodeValue<Person<Long>> newnv;
+    DurableSinglyLinkedList<Person<Long>> newnv;
     for (int i = 0; i < elem_count; ++i) {
       person = PersonFactory.create(m_act);
       person.setAge((short) m_rand.nextInt(50));
@@ -96,13 +96,13 @@ public class DurableNodeValueNGPrintTest {
       if (i + 1 == elem_count) {
         break;
       }
-      newnv = DurableNodeValueFactory.create(m_act, listefproxies, listgftypes, false);
+      newnv = DurableSinglyLinkedListFactory.create(m_act, listefproxies, listgftypes, false);
       nextnv.setNext(newnv, false);
       nextnv = newnv;
     }
 
     Person<Long> eval;
-    DurableNodeValue<Person<Long>> iternv = firstnv;
+    DurableSinglyLinkedList<Person<Long>> iternv = firstnv;
     System.out.printf(" -- Stage 1 Generated---\n");
     while (null != iternv) {
       eval = iternv.getItem();
@@ -115,8 +115,8 @@ public class DurableNodeValueNGPrintTest {
 
     long handler = firstnv.getHandler();
 
-    DurableNodeValue<Person<Long>> firstnv2 = DurableNodeValueFactory.restore(m_act, listefproxies, listgftypes,
-        handler, false);
+    DurableSinglyLinkedList<Person<Long>> firstnv2 = DurableSinglyLinkedListFactory.restore(m_act, listefproxies, 
+        listgftypes, handler, false);
 
     System.out.printf("--- Stage 2 Restored--- \n");
     for (Person<Long> eval2 : firstnv2) {
@@ -163,12 +163,12 @@ public class DurableNodeValueNGPrintTest {
         if (null != gfields && gfields.length >= 2) {
           val_gftypes = Arrays.copyOfRange(gfields, 1, gfields.length);
         }
-        return DurableNodeValueFactory.restore(allocator, val_efproxies, val_gftypes, phandler, autoreclaim);
+        return DurableSinglyLinkedListFactory.restore(allocator, val_efproxies, val_gftypes, phandler, autoreclaim);
       }
     } };
 
-    DurableNodeValue<DurableNodeValue<Double>> nextnv = null, pre_nextnv = null;
-    DurableNodeValue<Double> elem = null, pre_elem = null, first_elem = null;
+    DurableSinglyLinkedList<DurableSinglyLinkedList<Double>> nextnv = null, pre_nextnv = null;
+    DurableSinglyLinkedList<Double> elem = null, pre_elem = null, first_elem = null;
 
     Long linkhandler = 0L;
 
@@ -180,7 +180,7 @@ public class DurableNodeValueNGPrintTest {
       first_elem = null;
       pre_elem = null;
       for (int v = 0; v < 3; ++v) {
-        elem = DurableNodeValueFactory.create(m_act, elem_efproxies, elem_gftypes, false);
+        elem = DurableSinglyLinkedListFactory.create(m_act, elem_efproxies, elem_gftypes, false);
         val = m_rand.nextDouble();
         elem.setItem(val, false);
         if (null == pre_elem) {
@@ -192,7 +192,7 @@ public class DurableNodeValueNGPrintTest {
         System.out.printf("%f ", val);
       }
 
-      nextnv = DurableNodeValueFactory.create(m_act, linkedefproxies, linkedgftypes, false);
+      nextnv = DurableSinglyLinkedListFactory.create(m_act, linkedefproxies, linkedgftypes, false);
       nextnv.setItem(first_elem, false);
       if (null == pre_nextnv) {
         linkhandler = nextnv.getHandler();
@@ -206,9 +206,9 @@ public class DurableNodeValueNGPrintTest {
 
     long handler = m_act.getHandler(slotKeyId);
 
-    DurableNodeValue<DurableNodeValue<Double>> linkedvals = DurableNodeValueFactory.restore(m_act,
+    DurableSinglyLinkedList<DurableSinglyLinkedList<Double>> linkedvals = DurableSinglyLinkedListFactory.restore(m_act,
         linkedefproxies, linkedgftypes, handler, false);
-    Iterator<DurableNodeValue<Double>> iter = linkedvals.iterator();
+    Iterator<DurableSinglyLinkedList<Double>> iter = linkedvals.iterator();
     Iterator<Double> elemiter = null;
 
     System.out.printf(" Stage 2 -testLinkedNodeValueWithLinkedNodeValue--> \n");

--- a/mnemonic-computing-services/mnemonic-utilities-service/src/test/resources/testng.xml
+++ b/mnemonic-computing-services/mnemonic-utilities-service/src/test/resources/testng.xml
@@ -23,12 +23,12 @@
 <suite name="Suite" verbose="1" parallel="tests" thread-count="1">
   <test name="Test">
     <classes>
-      <class name="org.apache.mnemonic.service.computingservice.DurableNodeValueNGPrintTest"/> 
+      <class name="org.apache.mnemonic.service.computingservice.DurableSinglyLinkedListNGPrintTest"/> 
     </classes>
   </test> <!-- Test -->
 </suite> <!-- Suite -->
 
 
 <!--
-      <class name="org.apache.mnemonic.service.computingservice.DurableNodeValueNGPrintTest"/> 
+      <class name="org.apache.mnemonic.service.computingservice.DurableSinglyLinkedListNGPrintTest"/> 
  -->


### PR DESCRIPTION
The name of DurableNodeValue is not straightforward and intuitive so it is going to be renamed to DurableSinglyLinkedList.
