### PR TITLE
MNEMONIC-114: nvml-vmem-service compilation warnings

### DIFF
--- a/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl.c
+++ b/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl.c
@@ -111,10 +111,10 @@ jobject JNICALL Java_org_apache_mnemonic_service_memoryservice_internal_VMemServ
 
 JNIEXPORT
 jlong JNICALL Java_org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl_nretrieveSize(JNIEnv *env,
-    jobject this, jlong id, jlong addr, jlong size) {
+    jobject this, jlong id, jlong addr) {
   jlong ret = 0L;
   void* p = addr_from_java(addr);
-  ret = NULL != p ? (*env)->NewDirectByteBuffer(env, p, size) : NULL;
+  ret = NULL != p ? (*env)->GetDirectBufferAddress(env, p) : 0L;
   return ret;
 }
 
@@ -171,19 +171,21 @@ JNIEXPORT
 void JNICALL Java_org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl_nsetHandler(
     JNIEnv *env, jobject this, jlong id, jlong key, jlong value)
 {
-  throw(env, "setkey()/getkey() temporarily not suppoted");
+  throw(env, "setkey()/getkey() temporarily not supported");
 }
 
 JNIEXPORT
 jlong JNICALL Java_org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl_ngetHandler(JNIEnv *env,
     jobject this, jlong id, jlong key) {
-  throw(env, "setkey()/getkey() temporarily not suppoted");
+  throw(env, "setkey()/getkey() temporarily not supported");
+  return 0;
 }
 
 JNIEXPORT
 jlong JNICALL Java_org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl_nhandlerCapacity(
     JNIEnv *env, jobject this) {
-  throw(env, "setkey()/getkey() temporarily not suppoted");
+  throw(env, "setkey()/getkey() temporarily not supported");
+  return 0;
 }
 
 


### PR DESCRIPTION
Fixed several warnings during compile per Mnemonic-114 below.  Warning 194 was fixed in MNEMONIC-122.
## There are some warnings while compiling the sub-module mnemonic-nvml-vmem-service as follows

[exec] /home/wg/workspace/incubator-mnemonic/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl.c: In function ‘Java_org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl_nretrieveSize’:
[exec] /home/wg/workspace/incubator-mnemonic/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl.c:116: warning: assignment makes integer from pointer without a cast
[exec] /home/wg/workspace/incubator-mnemonic/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl.c: In function ‘Java_org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl_ngetBaseAddress’:
[exec] /home/wg/workspace/incubator-mnemonic/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl.c:194: warning: implicit declaration of function ‘b_addr’
[exec] /home/wg/workspace/incubator-mnemonic/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl.c: In function ‘Java_org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl_nhandlerCapacity’:
[exec] /home/wg/workspace/incubator-mnemonic/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl.c:186: warning: control reaches end of non-void function
[exec] /home/wg/workspace/incubator-mnemonic/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl.c: In function ‘Java_org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl_ngetHandler’:
[exec] /home/wg/workspace/incubator-mnemonic/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl.c:180: warning: control reaches end of non-void function
